### PR TITLE
Fix CMakeLists for gtest

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB_RECURSE GTEST_CPPS "gtest/googletest/src/*.cc")
+file(GLOB_RECURSE GTEST_CPPS "gtest/googletest/src/gtest-all.cc")
 file(GLOB_RECURSE GTEST_HPPS "gtest/googletest/include/*.h")
 
 include_directories(./gtest/googletest/include)


### PR DESCRIPTION
Файл `gtest-all.cc` содержал в себе все остальные файлы `*.cc`, поэтому при линковке возникала ошибка `multiple definition`. В сборку сейчас включен только один файл `gtest-all.cc`. 