### PR TITLE
Update CMake rules for cpplint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,5 @@ script:
   - mkdir build
   - cd build
   - cmake ..
-  - make lint
   - make
   - bin/tests

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB_RECURSE GTEST_CPPS "gtest/googletest/src/gtest-all.cc")
+file(GLOB GTEST_CPPS "gtest/googletest/src/gtest-all.cc")
 file(GLOB_RECURSE GTEST_HPPS "gtest/googletest/include/*.h")
 
 include_directories(./gtest/googletest/include)
@@ -6,7 +6,6 @@ include_directories(./gtest/googletest/)
 
 if(MSVC)
     #vc 2012 fix for vararg templates
-    #set(MSVC_COMPILER_DEFS "-D_VARIADIC_MAX=10")
     ADD_DEFINITIONS (/D_VARIADIC_MAX=10)
     MESSAGE(STATUS "MSVC: Set variadic max to 10 for MSVC compatibility")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,12 @@ SET( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake" )
 include_directories(include)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(-Wall -Wpedantic -Wextra -Werror)
+    add_compile_options(-Wall -Wpedantic -Wextra -Werror -Wconversion)
 endif()
 
 include(CppLint)
-
 
 add_subdirectory(3rdparty)
 add_subdirectory(src)
 add_subdirectory(test)
 
-file(GLOB LINT_FILES src/*.cpp test/*.cpp include/*.h include/*.hpp)
-add_style_check_target(lint_tests "${LINT_FILES}")
-add_custom_target(lint DEPENDS lint_tests VERBATIM)

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,4 @@
+set noparent
+linelength=120
+filter=-legal/copyright,-runtime/threadsafe_fn,-readability/utf8
+exclude_files=3rdparty

--- a/cmake/CppLint.cmake
+++ b/cmake/CppLint.cmake
@@ -1,84 +1,30 @@
-# Copyright (C) 2013 Daniel Scharrer
-#
-# This software is provided 'as-is', without any express or implied
-# warranty.  In no event will the author(s) be held liable for any damages
-# arising from the use of this software.
-#
-# Permission is granted to anyone to use this software for any purpose,
-# including commercial applications, and to alter it and redistribute it
-# freely, subject to the following restrictions:
-#
-# 1. The origin of this software must not be misrepresented; you must not
-#    claim that you wrote the original software. If you use this software
-#    in a product, an acknowledgment in the product documentation would be
-#    appreciated but is not required.
-# 2. Altered source versions must be plainly marked as such, and must not be
-#    misrepresented as being the original software.
-# 3. This notice may not be removed or altered from any source distribution.
-
-
-# Copyright (C) 2014 Greg Horn
-# In order to comply with the above copyright, I am noting that I took
-# Daniel's script and hacked it a bit, mostly changing paths and filters
-
+include(CMakeParseArguments)
 find_package(PythonInterp)
 
-set(STYLE_FILTER)
+set(LINTING_APP ${CMAKE_SOURCE_DIR}/3rdparty/cpplint.py)
+file(GLOB LINT_CONFIG ${CMAKE_SOURCE_DIR}/CPPLINT.cfg)
 
-# disable unwanted filters
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/braces,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/semicolon,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/blank_line,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/comma,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/operators,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/parens,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/indent,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/comments,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/newline,)
-#set(STYLE_FILTER ${STYLE_FILTER}-whitespace/tab,)
-#
-#set(STYLE_FILTER ${STYLE_FILTER}-build/include_order,)
-#set(STYLE_FILTER ${STYLE_FILTER}-build/namespaces,)
-#set(STYLE_FILTER ${STYLE_FILTER}-build/include_what_you_use,)
-#
-#set(STYLE_FILTER ${STYLE_FILTER}-readability/streams,)
-#set(STYLE_FILTER ${STYLE_FILTER}-readability/todo,)
-#
-#set(STYLE_FILTER ${STYLE_FILTER}-runtime/references,)
-#set(STYLE_FILTER ${STYLE_FILTER}-runtime/int,)
-#set(STYLE_FILTER ${STYLE_FILTER}-runtime/explicit,)
-#set(STYLE_FILTER ${STYLE_FILTER}-runtime/printf,)
-
-set(STYLE_FILTER ${STYLE_FILTER}-readability/utf8,)
-set(STYLE_FILTER ${STYLE_FILTER}-build/include,)
-set(STYLE_FILTER ${STYLE_FILTER}-runtime/threadsafe_fn,)
-set(STYLE_FILTER ${STYLE_FILTER}-legal/copyright,)
-
-# Add a target that runs cpplint.py
-#
-# Parameters:
-# - TARGET_NAME the name of the target to add
-# - SOURCES_LIST a complete list of source and include files to check
-function(add_style_check_target TARGET_NAME SOURCES_LIST)
+function(add_style_check_target)
     if(NOT PYTHONINTERP_FOUND)
+        message(WARNING "Skip linting, python not found")
         return()
     endif()
 
-    list(REMOVE_DUPLICATES SOURCES_LIST)
-    list(SORT SOURCES_LIST)
+    cmake_parse_arguments(LINT "" TARGET "SOURCES" ${ARGN})
+    if(NOT LINT_TARGET)
+        message(FATAL_ERROR "You must provide a target name")
+    endif(NOT LINT_TARGET)
 
-    add_custom_target(${TARGET_NAME}
+    list(REMOVE_DUPLICATES LINT_SOURCES)
+    list(SORT LINT_SOURCES)
+
+    add_custom_target(${LINT_TARGET} ALL
             COMMAND "${CMAKE_COMMAND}" -E chdir
             "${CMAKE_CURRENT_SOURCE_DIR}"
             "${PYTHON_EXECUTABLE}"
-            "${CMAKE_SOURCE_DIR}/3rdparty/cpplint.py"
-            "--filter=${STYLE_FILTER}"
-            "--counting=detailed"
-            "--extensions=cpp,hpp,h"
-            "--linelength=100"
-            ${SOURCES_LIST}
-            DEPENDS ${SOURCES_LIST}
-            COMMENT "Linting ${TARGET_NAME}"
-            VERBATIM)
-
+            ${LINTING_APP} ${LINT_SOURCES}
+            DEPENDS ${LINT_SOURCES}
+            COMMENT "Linting ${LINT_TARGET}"
+            VERBATIM
+            SOURCES ${LINTING_APP} ${LINT_CONFIG})
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,10 @@
+set(target code_lib)
+
 file(GLOB_RECURSE CPPS *.cpp)
 file(GLOB_RECURSE HPPS ../include/*.h ../include/*.hpp)
 
 include_directories(../include)
 
-add_library(code_lib ${CPPS} ${HPPS})
-
+add_style_check_target(TARGET ${target}_lint
+                       SOURCES ${CPPS} ${HPPS})
+add_library(${target} ${CPPS} ${HPPS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(target tests)
+
 file(GLOB CPPS *.cpp)
 file(GLOB HPPS ../include/*.h ../include/*.hpp)
 
@@ -8,15 +10,11 @@ link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 if(MSVC)
     #vc 2012 fix for vararg templates
-    #set(MSVC_COMPILER_DEFS "-D_VARIADIC_MAX=10")
     ADD_DEFINITIONS (/D_VARIADIC_MAX=10)
     MESSAGE(STATUS "MSVC: Set variadic max to 10 for MSVC compatibility")
 endif()
 
-add_executable(tests ${CPPS} ${HPPS})
-
-target_link_libraries(tests gtest code_lib ${CMAKE_THREAD_LIBS_INIT})
-#add_custom_command(TARGET tests
-#        POST_BUILD
-#        COMMAND bin/tests
-#        DEPENDS tests VERBATIM)
+add_style_check_target(TARGET ${target}_lint
+                       SOURCES ${CPPS} ${HPPS})
+add_executable(${target} ${CPPS} ${HPPS})
+target_link_libraries(${target} gtest code_lib ${CMAKE_THREAD_LIBS_INIT})

--- a/test/example.cpp
+++ b/test/example.cpp
@@ -1,5 +1,5 @@
-#include "gtest/gtest.h"
 #include <example.h>
+#include "gtest/gtest.h"
 
 TEST(Addition, CanAddTwoNumbers) {
   EXPECT_EQ(add(2, 2), 4);


### PR DESCRIPTION
1. Update CMake cpplint rules
2. Add `build/include` filter to cpplint
3. Remove commented lines
4. Fix minor linting error